### PR TITLE
fix(UI): Align sidebar and content list header dividers

### DIFF
--- a/LiteLog/Views/ContentView.swift
+++ b/LiteLog/Views/ContentView.swift
@@ -65,8 +65,9 @@ struct ContentView: View {
                     Button(action: { viewModel.refreshKeysAndLogs() }) {
                         Image(systemName: "arrow.clockwise")
                             .font(.system(size: 14))
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
                     }
-                    .buttonStyle(LinearButtonStyle(variant: .ghost))
+                    .buttonStyle(.plain)
                     .help("Refresh API Key list")
                 }
                 .padding(.horizontal, DesignSystem.Spacing.lg)


### PR DESCRIPTION
This PR fixes a UI alignment issue where the dividers under the "API Keys" and "Logs" headers were not horizontally aligned.

The misalignment was caused by extra padding on the new refresh button in the sidebar. This fix removes the custom button style and uses a plain style, ensuring both headers have the same height and the dividers are correctly aligned.