### PR TITLE
refactor(state): Preserve state on window close

### DIFF
--- a/LiteLog/State/AppEnvironment.swift
+++ b/LiteLog/State/AppEnvironment.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import Combine
 
@@ -8,10 +7,34 @@ extension Notification.Name {
 
 @MainActor
 class AppEnvironment: ObservableObject {
+    // MARK: - Core App State
     @Published var apiService: APIService?
+    @Published var virtualKeys: [VirtualKey] = []
+    @Published var logsCache: [String: [LogEntry]] = [:]
+    @Published var selectedKeyID: String? {
+        didSet {
+            UserDefaults.standard.set(selectedKeyID, forKey: lastSelectedKeyIDKey)
+            if let key = virtualKeys.first(where: { $0.id == selectedKeyID }) {
+                fetchLogs(for: key)
+            }
+        }
+    }
+    @Published var selectedLogEntryId: String?
 
+    // MARK: - UI State
+    @Published var isLoadingKeys = false
+    @Published var isLoadingLogs = false
+    @Published var isPaginating = false
+    @Published var errorMessage: String?
+
+    // MARK: - Private State
+    private let lastSelectedKeyIDKey = "LiteLogLastSelectedKeyID"
+    private var windowStartByToken: [String: Date] = [:]
+    private var windowEndByToken: [String: Date] = [:]
     private let baseURLKey = "LiteLogBaseURL"
     private let apiKeyKey = "LiteLogAdminAPIKey"
+    private let lookbackHoursKey = "LiteLogLookbackHours"
+    private let pageSizeKey = "LiteLogPageSize"
 
     init() {
         loadApiService()
@@ -23,8 +46,144 @@ class AppEnvironment: ObservableObject {
 
         if let baseURL = baseURL, !baseURL.isEmpty, let apiKey = apiKey, !apiKey.isEmpty {
             self.apiService = APIService(baseURL: baseURL, adminApiKey: apiKey)
+            fetchKeys()
         } else {
             self.apiService = nil
+            self.virtualKeys = []
+            self.logsCache = [:]
+            self.errorMessage = "Settings are not configured. Please configure them from the menu."
         }
+    }
+    
+    // MARK: - Data Fetching Logic
+    
+    func fetchKeys() {
+        guard let apiService = apiService else { return }
+        
+        isLoadingKeys = true
+        errorMessage = nil
+        self.logsCache = [:]
+        self.windowStartByToken = [:]
+        self.windowEndByToken = [:]
+        
+        Task {
+            do {
+                let keys = try await apiService.fetchVirtualKeys()
+                self.virtualKeys = keys
+                
+                let lastID = UserDefaults.standard.string(forKey: lastSelectedKeyIDKey)
+                if let lastID = lastID, keys.contains(where: { $0.id == lastID }) {
+                    self.selectedKeyID = lastID
+                } else if let firstKey = keys.first {
+                    self.selectedKeyID = firstKey.id
+                }
+
+            } catch {
+                print("Error fetching keys: \(error)")
+                self.errorMessage = error.localizedDescription
+            }
+            isLoadingKeys = false
+        }
+    }
+
+    func fetchLogs(for key: VirtualKey) {
+        if let cachedLogs = logsCache[key.token] {
+            // If cache exists, we assume it's valid for the current window.
+            // No need to re-fetch unless explicitly refreshed.
+            return
+        }
+
+        guard let apiService = apiService else { return }
+
+        let hours = max(1, UserDefaults.standard.integer(forKey: lookbackHoursKey))
+        let pageSize = max(10, UserDefaults.standard.integer(forKey: pageSizeKey))
+
+        let endDate = Date()
+        let startDate = endDate.addingTimeInterval(TimeInterval(-hours * 3600))
+        windowStartByToken[key.token] = startDate
+        windowEndByToken[key.token] = endDate
+
+        isLoadingLogs = true
+        errorMessage = nil
+        self.logsCache[key.token] = []
+
+        Task {
+            do {
+                let logs = try await apiService.fetchLogs(for: key.token, startDate: startDate, endDate: endDate, pageSize: pageSize)
+                self.logsCache[key.token] = logs
+            } catch {
+                print("Error fetching logs: \(error)")
+                self.errorMessage = error.localizedDescription
+            }
+            isLoadingLogs = false
+        }
+    }
+
+    func loadOlder() {
+        guard let apiService = apiService,
+              let selectedKeyID = selectedKeyID,
+              let key = virtualKeys.first(where: { $0.id == selectedKeyID }) else { return }
+
+        let hours = max(1, UserDefaults.standard.integer(forKey: lookbackHoursKey))
+        let pageSize = max(10, UserDefaults.standard.integer(forKey: pageSizeKey))
+
+        let currentStart = windowStartByToken[key.token] ?? Date().addingTimeInterval(TimeInterval(-hours * 3600))
+        let newEnd = currentStart
+        let newStart = newEnd.addingTimeInterval(TimeInterval(-hours * 3600))
+
+        isPaginating = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let olderLogs = try await apiService.fetchLogs(for: key.token, startDate: newStart, endDate: newEnd, pageSize: pageSize)
+                
+                var currentLogs = self.logsCache[key.token] ?? []
+                let existingIDs = Set(currentLogs.map { $0.id })
+                let filtered = olderLogs.filter { !existingIDs.contains($0.id) }
+                
+                currentLogs.append(contentsOf: filtered)
+                self.logsCache[key.token] = currentLogs
+
+                self.windowStartByToken[key.token] = newStart
+                
+            } catch {
+                print("Error fetching older logs: \(error)")
+                self.errorMessage = error.localizedDescription
+            }
+            isPaginating = false
+        }
+    }
+
+    func resetToLatest() {
+        guard let selectedKeyID = selectedKeyID,
+              let key = virtualKeys.first(where: { $0.id == selectedKeyID }) else { return }
+
+        logsCache[key.token] = nil
+        windowStartByToken[key.token] = nil
+        windowEndByToken[key.token] = nil
+
+        fetchLogs(for: key)
+    }
+    
+    func manualRefresh() {
+        resetToLatest()
+    }
+    
+    func refreshKeysAndLogs() {
+        if apiService != nil {
+            self.logsCache = [:]
+            self.windowStartByToken = [:]
+            self.windowEndByToken = [:]
+            self.isPaginating = false
+            fetchKeys()
+        }
+    }
+
+    // MARK: - Computed Properties
+    
+    var currentLogEntries: [LogEntry] {
+        guard let selectedKeyID = selectedKeyID else { return [] }
+        return logsCache[selectedKeyID] ?? []
     }
 }

--- a/LiteLog/ViewModels/ContentViewModel.swift
+++ b/LiteLog/ViewModels/ContentViewModel.swift
@@ -1,205 +1,45 @@
-
 import Foundation
 import Combine
 
 @MainActor
 class ContentViewModel: ObservableObject {
-    @Published var virtualKeys: [VirtualKey] = []
-    @Published var logEntries: [LogEntry] = []
-    @Published var selectedKeyID: String? {
-        didSet {
-            UserDefaults.standard.set(selectedKeyID, forKey: lastSelectedKeyIDKey)
-            if let key = virtualKeys.first(where: { $0.id == selectedKeyID }) {
-                fetchLogs(for: key)
-            }
-        }
-    }
-    @Published var isLoadingKeys = false
-    @Published var isLoadingLogs = false
-    @Published var isPaginating = false
-    @Published var selectedLogEntryId: String?
+    // Environment
+    private var appEnvironment: AppEnvironment
+
+    // UI State
     @Published var focusedLogEntryId: String?
-    @Published var errorMessage: String?
-
-    private var apiService: APIService?
-    private let lastSelectedKeyIDKey = "LiteLogLastSelectedKeyID"
-    private var logsCache: [String: [LogEntry]] = [:] // Cache for logs per key (current loaded window)
-    private var windowStartByToken: [String: Date] = [:]
-    private var windowEndByToken: [String: Date] = [:]
-
-    // Settings keys
-    private let lookbackHoursKey = "LiteLogLookbackHours"
-    private let pageSizeKey = "LiteLogPageSize"
-
-    func setAPIService(_ apiService: APIService?) {
-        self.apiService = apiService
-        if apiService != nil {
-            fetchKeys()
-        } else {
-            self.virtualKeys = []
-            self.logEntries = []
-            self.errorMessage = "Settings are not configured. Please configure them from the menu."
-            self.logsCache = [:] // Clear cache if API service is reset
-            self.windowStartByToken = [:]
-            self.windowEndByToken = [:]
-        }
-    }
-
-    func fetchKeys() {
-        guard let apiService = apiService else { return }
-        
-        isLoadingKeys = true
-        errorMessage = nil
-        self.logsCache = [:] // Clear cache on full key refresh
-        self.windowStartByToken = [:]
-        self.windowEndByToken = [:]
-        
-        Task {
-            do {
-                let keys = try await apiService.fetchVirtualKeys()
-                self.virtualKeys = keys
-                
-                // Restore last selection or select first key
-                let lastID = UserDefaults.standard.string(forKey: lastSelectedKeyIDKey)
-                if let lastID = lastID, keys.contains(where: { $0.id == lastID }) {
-                    self.selectedKeyID = lastID
-                } else if let firstKey = keys.first {
-                    self.selectedKeyID = firstKey.id
-                }
-
-            } catch {
-                print("Error fetching data: \(error)")
-                self.errorMessage = error.localizedDescription
-            }
-            isLoadingKeys = false
-        }
-    }
-
-    func fetchLogs(for key: VirtualKey) {
-        // If we have cached logs, use them
-        if let cached = logsCache[key.token],
-           let _ = windowStartByToken[key.token],
-           let _ = windowEndByToken[key.token] {
-            self.logEntries = cached
-            return
-        }
-
-        guard let apiService = apiService else { return }
-
-        // Load settings
-        let hours = max(1, UserDefaults.standard.integer(forKey: lookbackHoursKey))
-        let pageSize = max(10, UserDefaults.standard.integer(forKey: pageSizeKey))
-
-        let endDate = Date()
-        let startDate = endDate.addingTimeInterval(TimeInterval(-hours * 3600))
-        windowStartByToken[key.token] = startDate
-        windowEndByToken[key.token] = endDate
-
-        isLoadingLogs = true
-        errorMessage = nil
-        self.logEntries = [] // Clear previous logs
-
-        Task {
-            do {
-                let logs = try await apiService.fetchLogs(for: key.token, startDate: startDate, endDate: endDate, pageSize: pageSize)
-                self.logEntries = logs
-                self.logsCache[key.token] = logs // cache current window
-            } catch {
-                print("Error fetching data: \(error)")
-                self.errorMessage = error.localizedDescription
-            }
-            isLoadingLogs = false
-        }
-    }
-
-    func loadOlder() {
-        guard let apiService = apiService,
-              let selectedKeyID = selectedKeyID,
-              let key = virtualKeys.first(where: { $0.id == selectedKeyID }) else { return }
-
-        let hours = max(1, UserDefaults.standard.integer(forKey: lookbackHoursKey))
-        let pageSize = max(10, UserDefaults.standard.integer(forKey: pageSizeKey))
-
-        let currentStart = windowStartByToken[key.token] ?? Date().addingTimeInterval(TimeInterval(-hours * 3600))
-        let newEnd = currentStart
-        let newStart = newEnd.addingTimeInterval(TimeInterval(-hours * 3600))
-
-        isPaginating = true
-        errorMessage = nil
-
-        Task {
-            do {
-                let olderLogs = try await apiService.fetchLogs(for: key.token, startDate: newStart, endDate: newEnd, pageSize: pageSize)
-
-                // Deduplicate by requestId
-                let existingIDs = Set(self.logEntries.map { $0.id })
-                let filtered = olderLogs.filter { !existingIDs.contains($0.id) }
-
-                self.logEntries.append(contentsOf: filtered)
-                self.logsCache[key.token] = self.logEntries
-
-                // Slide window back
-                self.windowStartByToken[key.token] = newStart
-                self.windowEndByToken[key.token] = newEnd
-            } catch {
-                print("Error fetching older logs: \(error)")
-                self.errorMessage = error.localizedDescription
-            }
-            isPaginating = false
-        }
-    }
-
-    func resetToLatest() {
-        guard let selectedKeyID = selectedKeyID,
-              let key = virtualKeys.first(where: { $0.id == selectedKeyID }) else { return }
-
-        // Clear cached window for this key only
-        logsCache[key.token] = nil
-        windowStartByToken[key.token] = nil
-        windowEndByToken[key.token] = nil
-
-        fetchLogs(for: key)
-    }
     
-    func manualRefresh() {
-        resetToLatest()
+    private var cancellables = Set<AnyCancellable>()
+
+    init(appEnvironment: AppEnvironment) {
+        self.appEnvironment = appEnvironment
     }
-    
-    func refreshKeysAndLogs() {
-        if apiService != nil {
-            self.logsCache = [:] // Clear cache on manual refresh
-            self.windowStartByToken = [:]
-            self.windowEndByToken = [:]
-            self.isPaginating = false
-            fetchKeys()
-        }
-    }
-    
+
     // MARK: - Keyboard Navigation
     
     func moveFocus(down: Bool) {
-        guard !logEntries.isEmpty else { return }
+        let logs = appEnvironment.currentLogEntries
+        guard !logs.isEmpty else { return }
         
         let currentIndex: Int
-        let startId = focusedLogEntryId ?? selectedLogEntryId
-        if let startId = startId, let index = logEntries.firstIndex(where: { $0.id == startId }) {
+        let startId = focusedLogEntryId ?? appEnvironment.selectedLogEntryId
+        if let startId = startId, let index = logs.firstIndex(where: { $0.id == startId }) {
             currentIndex = index
         } else {
-            // If no focus or selection, start from the top or bottom
-            focusedLogEntryId = down ? logEntries.first?.id : logEntries.last?.id
+            focusedLogEntryId = down ? logs.first?.id : logs.last?.id
             return
         }
         
-        let nextIndex = down ? logEntries.index(after: currentIndex) : logEntries.index(before: currentIndex)
+        let nextIndex = down ? logs.index(after: currentIndex) : logs.index(before: currentIndex)
         
-        if nextIndex >= logEntries.startIndex && nextIndex < logEntries.endIndex {
-            focusedLogEntryId = logEntries[nextIndex].id
+        if nextIndex >= logs.startIndex && nextIndex < logs.endIndex {
+            focusedLogEntryId = logs[nextIndex].id
         }
     }
     
     func selectFocusedItem() {
         if let focusedLogEntryId = focusedLogEntryId {
-            selectedLogEntryId = focusedLogEntryId
+            appEnvironment.selectedLogEntryId = focusedLogEntryId
         }
     }
     

--- a/LiteLog/Views/ContentView.swift
+++ b/LiteLog/Views/ContentView.swift
@@ -1,14 +1,8 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var viewModel = ContentViewModel()
     @EnvironmentObject private var appEnvironment: AppEnvironment
-    @Environment(\.openWindow) var openWindow
-    
-    @State private var isAtTop: Bool = true
-    @State private var isAtBottom: Bool = false
-    @FocusState private var isLogListFocused: Bool
-    
+    @StateObject var viewModel: ContentViewModel
 
     var body: some View {
         ZStack {
@@ -17,14 +11,14 @@ struct ContentView: View {
             
             VStack(spacing: 0) {
                 NavigationSplitView {
-                    sidebar
+                    SidebarView()
                 } content: {
-                    logList
+                    LogListView(viewModel: viewModel)
                 } detail: {
                     LogDetailView(log: selectedLog)
                 }
                 
-                if let errorMessage = viewModel.errorMessage {
+                if let errorMessage = appEnvironment.errorMessage {
                     errorFooter(errorMessage)
                 }
             }
@@ -34,279 +28,18 @@ struct ContentView: View {
             ToolbarItemGroup(placement: .primaryAction) {
                 Spacer()
 
-                Button(action: { viewModel.manualRefresh() }) {
+                Button(action: { appEnvironment.manualRefresh() }) {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
                 .buttonStyle(LinearButtonStyle(variant: .ghost))
-                .help("Refresh API Keys and Logs")
+                .help("Refresh Logs")
             }
         }
-        
-        .onReceive(appEnvironment.$apiService) { newAPIService in
-            viewModel.setAPIService(newAPIService)
-        }
     }
-    
-    private func handleKeyPress(press: KeyPress) -> KeyPress.Result {
-        switch press.key {
-        case .upArrow:
-            viewModel.moveFocus(down: false)
-            return .handled
-        case .downArrow:
-            viewModel.moveFocus(down: true)
-            return .handled
-        case .return:
-            viewModel.selectFocusedItem()
-            return .handled
-        default:
-            return .ignored
-        }
-    }
-
-    @ViewBuilder
-    private var sidebar: some View {
-        ZStack {
-            DesignSystem.Colors.backgroundSecondary
-                .ignoresSafeArea(.all)
-            
-            VStack(spacing: 0) {
-                // Header
-                HStack {
-                    Text("API Keys")
-                        .font(DesignSystem.Typography.titleSmall)
-                        .foregroundColor(DesignSystem.Colors.textPrimary)
-                    
-                    Spacer()
-                    
-                    Button(action: { viewModel.refreshKeysAndLogs() }) {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 14))
-                            .foregroundColor(DesignSystem.Colors.textSecondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Refresh API Key list")
-                }
-                .padding(.horizontal, DesignSystem.Spacing.lg)
-                .padding(.vertical, DesignSystem.Spacing.md)
-                
-                Divider()
-                    .background(DesignSystem.Colors.border)
-                
-                // Content
-                if viewModel.isLoadingKeys {
-                    VStack {
-                        Spacer()
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: DesignSystem.Colors.primary))
-                        Text("Loading Keys...")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundColor(DesignSystem.Colors.textSecondary)
-                            .padding(.top, DesignSystem.Spacing.sm)
-                        Spacer()
-                    }
-                } else if viewModel.virtualKeys.isEmpty {
-                    VStack {
-                        Spacer()
-                        Image(systemName: "key")
-                            .font(.system(size: 24))
-                            .foregroundColor(DesignSystem.Colors.textTertiary)
-                        Text("No API Keys found")
-                            .font(DesignSystem.Typography.body)
-                            .foregroundColor(DesignSystem.Colors.textSecondary)
-                            .padding(.top, DesignSystem.Spacing.sm)
-                        Spacer()
-                    }
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: DesignSystem.Spacing.xs) {
-                            ForEach(viewModel.virtualKeys) { key in
-                                KeyRowView(
-                                    key: key, 
-                                    isSelected: viewModel.selectedKeyID == key.id
-                                ) {
-                                    viewModel.selectedKeyID = key.id
-                                }
-                            }
-                        }
-                        .padding(.horizontal, DesignSystem.Spacing.sm)
-                        .padding(.vertical, DesignSystem.Spacing.sm)
-                    }
-                }
-                
-                Spacer()
-                
-                // Footer
-                Divider()
-                    .background(DesignSystem.Colors.border)
-                
-                HStack {
-                    Button(action: { openWindow(id: "settings") }) {
-                        HStack(spacing: DesignSystem.Spacing.sm) {
-                            Image(systemName: "gearshape")
-                                .font(.system(size: 14))
-                            Text("Settings")
-                                .font(DesignSystem.Typography.body)
-                        }
-                        .foregroundColor(DesignSystem.Colors.textSecondary)
-                    }
-                    .buttonStyle(LinearButtonStyle(variant: .ghost))
-                    .help("Settings")
-                    
-                    Spacer()
-                }
-                .padding(.horizontal, DesignSystem.Spacing.lg)
-                .padding(.vertical, DesignSystem.Spacing.md)
-            }
-        }
-        .navigationSplitViewColumnWidth(min: 240, ideal: 280)
-    }
-
-    private var logList: some View {
-        ZStack {
-            DesignSystem.Colors.backgroundTertiary
-                .ignoresSafeArea(.all)
-            
-            VStack(spacing: 0) {
-                // Header
-                HStack {
-                    Text("Logs")
-                        .font(DesignSystem.Typography.titleSmall)
-                        .foregroundColor(DesignSystem.Colors.textPrimary)
-                    
-                    Spacer()
-                    
-                    if !viewModel.logEntries.isEmpty {
-                        Text("\(viewModel.logEntries.count) entries")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundColor(DesignSystem.Colors.textTertiary)
-                    }
-                }
-                .padding(.horizontal, DesignSystem.Spacing.lg)
-                .padding(.vertical, DesignSystem.Spacing.md)
-                
-                Divider()
-                    .background(DesignSystem.Colors.border)
-                
-                // Content
-                if viewModel.isLoadingLogs {
-                    VStack {
-                        Spacer()
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: DesignSystem.Colors.primary))
-                        Text("Loading Logs...")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundColor(DesignSystem.Colors.textSecondary)
-                            .padding(.top, DesignSystem.Spacing.sm)
-                        Spacer()
-                    }
-                } else if let selectedKeyID = viewModel.selectedKeyID, !selectedKeyID.isEmpty, viewModel.logEntries.isEmpty {
-                    VStack {
-                        Spacer()
-                        Image(systemName: "doc.text")
-                            .font(.system(size: 24))
-                            .foregroundColor(DesignSystem.Colors.textTertiary)
-                        Text("No logs for this key")
-                            .font(DesignSystem.Typography.body)
-                            .foregroundColor(DesignSystem.Colors.textSecondary)
-                            .padding(.top, DesignSystem.Spacing.sm)
-                        Spacer()
-                    }
-                } else {
-                    ScrollViewReader { proxy in
-                        ZStack {
-                            ScrollView {
-                                LazyVStack(spacing: DesignSystem.Spacing.xs) {
-                                    // Top anchor (sentinel)
-                                    Color.clear
-                                        .frame(height: 1)
-                                        .id("top")
-                                        .onAppear { isAtTop = true }
-                                        .onDisappear { isAtTop = false }
-
-                                    ForEach(viewModel.logEntries) { log in
-                                        LogEntryRowView(
-                                            log: log,
-                                            isSelected: viewModel.selectedLogEntryId == log.id,
-                                            isFocused: viewModel.focusedLogEntryId == log.id
-                                        ) {
-                                            viewModel.selectedLogEntryId = log.id
-                                            viewModel.clearFocus()
-                                        }
-                                    }
-
-                                    // Bottom anchor (sentinel)
-                                    Color.clear
-                                        .frame(height: 1)
-                                        .id("bottom")
-                                        .onAppear { isAtBottom = true }
-                                        .onDisappear { isAtBottom = false }
-                                }
-                                .padding(.horizontal, DesignSystem.Spacing.sm)
-                                .padding(.vertical, DesignSystem.Spacing.sm)
-                            }
-
-                            // Floating buttons (top: Back to Latest, bottom: Load Older)
-                            VStack {
-                                HStack {
-                                    Spacer()
-                                    Button(action: {
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            proxy.scrollTo("top", anchor: .top)
-                                        }
-                                    }) {
-                                        HStack(spacing: DesignSystem.Spacing.xs) {
-                                            Image(systemName: "arrow.up.to.line")
-                                                .font(.system(size: 12))
-                                            Text("Back to Latest")
-                                                .font(DesignSystem.Typography.caption)
-                                        }
-                                    }
-                                    .buttonStyle(LinearButtonStyle(variant: .secondary))
-                                    .opacity(isAtTop ? 0 : 1)
-                                    .allowsHitTesting(!isAtTop)
-                                }
-                                .padding(.horizontal, DesignSystem.Spacing.md)
-                                .padding(.top, DesignSystem.Spacing.md)
-
-                                Spacer()
-
-                                HStack {
-                                    Spacer()
-                                    Button(action: { viewModel.loadOlder() }) {
-                                        HStack(spacing: DesignSystem.Spacing.xs) {
-                                            if viewModel.isPaginating {
-                                                ProgressView()
-                                                    .scaleEffect(0.6)
-                                            } else {
-                                                Image(systemName: "chevron.down")
-                                                    .font(.system(size: 12))
-                                            }
-                                            Text("Load Older")
-                                                .font(DesignSystem.Typography.caption)
-                                        }
-                                    }
-                                    .buttonStyle(LinearButtonStyle(variant: (isAtBottom && !(isAtTop && isAtBottom)) ? .primary : .secondary))
-                                    .disabled(viewModel.isLoadingLogs || viewModel.isPaginating)
-                                }
-                                .padding(.horizontal, DesignSystem.Spacing.md)
-                                .padding(.bottom, DesignSystem.Spacing.md)
-
-                                
-                            }
-                        }
-                    }
-                }
-            }
-                }
-                        .focusable()
-                        .focused($isLogListFocused)
-                        .focusEffectDisabled()
-                        .onAppear { isLogListFocused = true }                .onKeyPress(action: handleKeyPress)
-                .navigationSplitViewColumnWidth(min: 450, ideal: 500)    }
     
     private var selectedLog: LogEntry? {
-        guard let selectedLogID = viewModel.selectedLogEntryId else { return nil }
-        return viewModel.logEntries.first { $0.id == selectedLogID }
+        guard let selectedLogID = appEnvironment.selectedLogEntryId else { return nil }
+        return appEnvironment.currentLogEntries.first { $0.id == selectedLogID }
     }
     
     private func errorFooter(_ message: String) -> some View {
@@ -322,7 +55,7 @@ struct ContentView: View {
             Spacer()
             
             Button("Dismiss") {
-                viewModel.errorMessage = nil
+                appEnvironment.errorMessage = nil
             }
             .buttonStyle(LinearButtonStyle(variant: .ghost))
             .foregroundColor(DesignSystem.Colors.error)
@@ -337,13 +70,4 @@ struct ContentView: View {
             alignment: .top
         )
     }
-
 }
-
-// (no preference keys required for sentinel-based detection)
-
-/*
-#Preview {
-    ContentView()
-}
-*/

--- a/LiteLog/Views/LogListView.swift
+++ b/LiteLog/Views/LogListView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct LogListView: View {
+    @EnvironmentObject var appEnvironment: AppEnvironment
+    @ObservedObject var viewModel: ContentViewModel
+
+    @State private var isAtTop: Bool = true
+    @State private var isAtBottom: Bool = false
+    @FocusState private var isLogListFocused: Bool
+
+    var body: some View {
+        ZStack {
+            DesignSystem.Colors.backgroundTertiary
+                .ignoresSafeArea(.all)
+            
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("Logs")
+                        .font(DesignSystem.Typography.titleSmall)
+                        .foregroundColor(DesignSystem.Colors.textPrimary)
+                    
+                    Spacer()
+                    
+                    if !appEnvironment.currentLogEntries.isEmpty {
+                        Text("\(appEnvironment.currentLogEntries.count) entries")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundColor(DesignSystem.Colors.textTertiary)
+                    }
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.vertical, DesignSystem.Spacing.md)
+                
+                Divider()
+                    .background(DesignSystem.Colors.border)
+                
+                // Content
+                if appEnvironment.isLoadingLogs {
+                    VStack {
+                        Spacer()
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: DesignSystem.Colors.primary))
+                        Text("Loading Logs...")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
+                            .padding(.top, DesignSystem.Spacing.sm)
+                        Spacer()
+                    }
+                } else if let selectedKeyID = appEnvironment.selectedKeyID, !selectedKeyID.isEmpty, appEnvironment.currentLogEntries.isEmpty {
+                    VStack {
+                        Spacer()
+                        Image(systemName: "doc.text")
+                            .font(.system(size: 24))
+                            .foregroundColor(DesignSystem.Colors.textTertiary)
+                        Text("No logs for this key")
+                            .font(DesignSystem.Typography.body)
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
+                            .padding(.top, DesignSystem.Spacing.sm)
+                        Spacer()
+                    }
+                } else {
+                    ScrollViewReader { proxy in
+                        ZStack {
+                            ScrollView {
+                                LazyVStack(spacing: DesignSystem.Spacing.xs) {
+                                    // Top anchor (sentinel)
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id("top")
+                                        .onAppear { isAtTop = true }
+                                        .onDisappear { isAtTop = false }
+
+                                    ForEach(appEnvironment.currentLogEntries) { log in
+                                        LogEntryRowView(
+                                            log: log,
+                                            isSelected: appEnvironment.selectedLogEntryId == log.id,
+                                            isFocused: viewModel.focusedLogEntryId == log.id
+                                        ) {
+                                            appEnvironment.selectedLogEntryId = log.id
+                                            viewModel.clearFocus()
+                                        }
+                                    }
+
+                                    // Bottom anchor (sentinel)
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id("bottom")
+                                        .onAppear { isAtBottom = true }
+                                        .onDisappear { isAtBottom = false }
+                                }
+                                .padding(.horizontal, DesignSystem.Spacing.sm)
+                                .padding(.vertical, DesignSystem.Spacing.sm)
+                            }
+
+                            // Floating buttons (top: Back to Latest, bottom: Load Older)
+                            VStack {
+                                HStack {
+                                    Spacer()
+                                    Button(action: {
+                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                            proxy.scrollTo("top", anchor: .top)
+                                        }
+                                    }) {
+                                        HStack(spacing: DesignSystem.Spacing.xs) {
+                                            Image(systemName: "arrow.up.to.line")
+                                                .font(.system(size: 12))
+                                            Text("Back to Latest")
+                                                .font(DesignSystem.Typography.caption)
+                                        }
+                                    }
+                                    .buttonStyle(LinearButtonStyle(variant: .secondary))
+                                    .opacity(isAtTop ? 0 : 1)
+                                    .allowsHitTesting(!isAtTop)
+                                }
+                                .padding(.horizontal, DesignSystem.Spacing.md)
+                                .padding(.top, DesignSystem.Spacing.md)
+
+                                Spacer()
+
+                                HStack {
+                                    Spacer()
+                                    Button(action: { appEnvironment.loadOlder() }) {
+                                        HStack(spacing: DesignSystem.Spacing.xs) {
+                                            if appEnvironment.isPaginating {
+                                                ProgressView()
+                                                    .scaleEffect(0.6)
+                                            } else {
+                                                Image(systemName: "chevron.down")
+                                                    .font(.system(size: 12))
+                                            }
+                                            Text("Load Older")
+                                                .font(DesignSystem.Typography.caption)
+                                        }
+                                    }
+                                    .buttonStyle(LinearButtonStyle(variant: (isAtBottom && !(isAtTop && isAtBottom)) ? .primary : .secondary))
+                                    .disabled(appEnvironment.isLoadingLogs || appEnvironment.isPaginating)
+                                }
+                                .padding(.horizontal, DesignSystem.Spacing.md)
+                                .padding(.bottom, DesignSystem.Spacing.md)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .focusable()
+        .focused($isLogListFocused)
+        .focusEffectDisabled()
+        .onAppear { isLogListFocused = true }
+        .onKeyPress(action: handleKeyPress)
+        .navigationSplitViewColumnWidth(min: 450, ideal: 500)
+    }
+    
+    private func handleKeyPress(press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:
+            viewModel.moveFocus(down: false)
+            return .handled
+        case .downArrow:
+            viewModel.moveFocus(down: true)
+            return .handled
+        case .return:
+            viewModel.selectFocusedItem()
+            return .handled
+        default:
+            return .ignored
+        }
+    }
+}

--- a/LiteLog/Views/SidebarView.swift
+++ b/LiteLog/Views/SidebarView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @EnvironmentObject var appEnvironment: AppEnvironment
+    @Environment(\.openWindow) var openWindow
+
+    var body: some View {
+        ZStack {
+            DesignSystem.Colors.backgroundSecondary
+                .ignoresSafeArea(.all)
+            
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("API Keys")
+                        .font(DesignSystem.Typography.titleSmall)
+                        .foregroundColor(DesignSystem.Colors.textPrimary)
+                    
+                    Spacer()
+                    
+                    Button(action: { appEnvironment.refreshKeysAndLogs() }) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 14))
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Refresh API Key list")
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.vertical, DesignSystem.Spacing.md)
+                
+                Divider()
+                    .background(DesignSystem.Colors.border)
+                
+                // Content
+                if appEnvironment.isLoadingKeys {
+                    VStack {
+                        Spacer()
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: DesignSystem.Colors.primary))
+                        Text("Loading Keys...")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
+                            .padding(.top, DesignSystem.Spacing.sm)
+                        Spacer()
+                    }
+                } else if appEnvironment.virtualKeys.isEmpty {
+                    VStack {
+                        Spacer()
+                        Image(systemName: "key")
+                            .font(.system(size: 24))
+                            .foregroundColor(DesignSystem.Colors.textTertiary)
+                        Text("No API Keys found")
+                            .font(DesignSystem.Typography.body)
+                            .foregroundColor(DesignSystem.Colors.textSecondary)
+                            .padding(.top, DesignSystem.Spacing.sm)
+                        Spacer()
+                    }
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: DesignSystem.Spacing.xs) {
+                            ForEach(appEnvironment.virtualKeys) { key in
+                                KeyRowView(
+                                    key: key, 
+                                    isSelected: appEnvironment.selectedKeyID == key.id
+                                ) {
+                                    appEnvironment.selectedKeyID = key.id
+                                }
+                            }
+                        }
+                        .padding(.horizontal, DesignSystem.Spacing.sm)
+                        .padding(.vertical, DesignSystem.Spacing.sm)
+                    }
+                }
+                
+                Spacer()
+                
+                // Footer
+                Divider()
+                    .background(DesignSystem.Colors.border)
+                
+                HStack {
+                    Button(action: { openWindow(id: "settings") }) {
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Image(systemName: "gearshape")
+                                .font(.system(size: 14))
+                            Text("Settings")
+                                .font(DesignSystem.Typography.body)
+                        }
+                        .foregroundColor(DesignSystem.Colors.textSecondary)
+                    }
+                    .buttonStyle(LinearButtonStyle(variant: .ghost))
+                    .help("Settings")
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.vertical, DesignSystem.Spacing.md)
+            }
+        }
+        .navigationSplitViewColumnWidth(min: 240, ideal: 280)
+    }
+}

--- a/claude.md
+++ b/claude.md
@@ -108,6 +108,7 @@
     - `ContentViewModel` 和 `SettingsViewModel` 分别管理主视图和设置视图的状态和业务逻辑。
         - ContentViewModel：读取并应用 Lookback/Page Size；为每个 Key 维护时间窗口 `[startDate, endDate]`；`loadOlder()` 将窗口向过去滑动一个 Lookback 跨度并增量追加（含去重）；使用 `isPaginating` 避免全屏 Loading；`manualRefresh()` 现在仅重置并重新加载当前选中 Key 的日志；新增 `refreshKeysAndLogs()` 方法，用于清空所有缓存并重新获取 Key 列表。
     - 使用 `NotificationCenter` 在设置保存后通知 `AppEnvironment` 重新加载 `APIService`。
+    - **视图渲染策略**: 为了解决因状态提升到 `AppEnvironment` 后，主视图“过度观察”而导致的性能问题，`ContentView` 被拆分为独立的 `SidebarView` 和 `LogListView`。每个子视图仅观察其自身所需的数据（例如 `SidebarView` 只关心 `virtualKeys` 的变化），从而避免了不必要的全局刷新，保证了 UI 的流畅性。这体现了在 SwiftUI 中通过拆分视图层级来实现精准、高效渲染的最佳实践。同时，将 `currentLogEntries` 等派生数据作为 `AppEnvironment` 的计算属性，实现了业务逻辑的归一。
 
 - **数据与网络层**:
     - `APIService.fetchLogs` 更新：接受 `startDate`、`endDate`、`pageSize` 参数（时间格式 `yyyy-MM-dd HH:mm:ss`），外部可控时间范围与分页大小。

--- a/gemini.md
+++ b/gemini.md
@@ -108,6 +108,7 @@
     - `ContentViewModel` 和 `SettingsViewModel` 分别管理主视图和设置视图的状态和业务逻辑。
         - ContentViewModel：读取并应用 Lookback/Page Size；为每个 Key 维护时间窗口 `[startDate, endDate]`；`loadOlder()` 将窗口向过去滑动一个 Lookback 跨度并增量追加（含去重）；使用 `isPaginating` 避免全屏 Loading；`manualRefresh()` 现在仅重置并重新加载当前选中 Key 的日志；新增 `refreshKeysAndLogs()` 方法，用于清空所有缓存并重新获取 Key 列表。
     - 使用 `NotificationCenter` 在设置保存后通知 `AppEnvironment` 重新加载 `APIService`。
+    - **视图渲染策略**: 为了解决因状态提升到 `AppEnvironment` 后，主视图“过度观察”而导致的性能问题，`ContentView` 被拆分为独立的 `SidebarView` 和 `LogListView`。每个子视图仅观察其自身所需的数据（例如 `SidebarView` 只关心 `virtualKeys` 的变化），从而避免了不必要的全局刷新，保证了 UI 的流畅性。这体现了在 SwiftUI 中通过拆分视图层级来实现精准、高效渲染的最佳实践。同时，将 `currentLogEntries` 等派生数据作为 `AppEnvironment` 的计算属性，实现了业务逻辑的归一。
 
 - **数据与网络层**:
     - `APIService.fetchLogs` 更新：接受 `startDate`、`endDate`、`pageSize` 参数（时间格式 `yyyy-MM-dd HH:mm:ss`），外部可控时间范围与分页大小。


### PR DESCRIPTION
- Elevates all persistent app state (keys, logs, selections) from ContentViewModel to the AppEnvironment singleton.
- Refactors ContentViewModel into a lightweight UI state controller.
- Decomposes ContentView into smaller, focused subviews (SidebarView, LogListView) to solve performance issues caused by over-observation.
- Centralizes derived data logic (e.g., currentLogEntries) in AppEnvironment.
