### PR TITLE
feat(ui): Implement Formatted / JSON Views for Log Details

### DIFF
--- a/LiteLog/Models/Payload.swift
+++ b/LiteLog/Models/Payload.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct ChatMessage: Codable, Hashable, Identifiable {
+    var id = UUID()
+    let role: String
+    let content: String?
+    let toolCalls: [ToolCall]?
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case content
+        case toolCalls = "tool_calls"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.role = try container.decode(String.self, forKey: .role)
+        self.content = try container.decodeIfPresent(String.self, forKey: .content)
+        self.toolCalls = try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
+        
+        // If content is nil and toolCalls is also nil, it's an invalid message, but we'll allow it for now.
+        // If content is nil, but toolCalls exist, we should ensure content is not just an empty string.
+        // For now, we'll keep content as optional String.
+    }
+}
+
+struct ToolCall: Codable, Hashable, Identifiable {
+    var id: String // This is the 'id' from the JSON, e.g., "call_vaIva6JAahiDBmj3Ut6xfFq0"
+    let type: String
+    let function: FunctionCall
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case function
+    }
+}
+
+struct FunctionCall: Codable, Hashable {
+    let name: String
+    let arguments: String // Arguments are typically a JSON string
+}
+
+struct ChatRequestPayload: Codable {
+    let messages: [ChatMessage]
+}
+
+struct ChatResponsePayload: Codable {
+    let choices: [Choice]
+}
+
+struct Choice: Codable {
+    let message: ChatMessage
+}

--- a/LiteLog/Views/FormattedView.swift
+++ b/LiteLog/Views/FormattedView.swift
@@ -1,0 +1,122 @@
+
+import SwiftUI
+
+struct FormattedView: View {
+    let requestPayload: Data?
+    let responsePayload: Data?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxl) {
+                if let messages = extractMessages() {
+                    ForEach(messages) { message in
+                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                            Text(message.role.capitalized)
+                                .font(DesignSystem.Typography.titleSmall)
+                                .foregroundColor(DesignSystem.Colors.textSecondary)
+                                .padding(.horizontal, DesignSystem.Spacing.md)
+
+                            MessageCard(message: message)
+                        }
+                    }
+                } else {
+                    Text("No messages found in payload.")
+                        .foregroundColor(DesignSystem.Colors.textSecondary)
+                        .padding()
+                }
+            }
+            .padding(DesignSystem.Spacing.xl)
+        }
+        .frame(minHeight: 400)
+    }
+
+    private func extractMessages() -> [ChatMessage]? {
+        var messages: [ChatMessage] = []
+
+        if let requestData = requestPayload {
+            let decoder = JSONDecoder()
+            if let request = try? decoder.decode(ChatRequestPayload.self, from: requestData) {
+                messages.append(contentsOf: request.messages)
+            }
+        }
+
+        if let responseData = responsePayload {
+            let decoder = JSONDecoder()
+            if let response = try? decoder.decode(ChatResponsePayload.self, from: responseData),
+               let choice = response.choices.first {
+                messages.append(choice.message)
+            }
+        }
+
+        return messages.isEmpty ? nil : messages
+    }
+}
+
+struct MessageCard: View {
+    let message: ChatMessage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack {
+                Spacer()
+                Button(action: {
+                    copyToClipboard(message)
+                }) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 12))
+                        .foregroundColor(DesignSystem.Colors.textSecondary)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            
+            if let content = message.content, !content.isEmpty {
+                Text(content)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundColor(DesignSystem.Colors.textPrimary)
+                    .textSelection(.enabled)
+            } else if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    ForEach(toolCalls) { toolCall in
+                        VStack(alignment: .leading) {
+                            Text("Tool Call: \(toolCall.function.name)")
+                                .font(DesignSystem.Typography.bodyMedium)
+                                .foregroundColor(DesignSystem.Colors.textPrimary)
+                            Text("Arguments: \(toolCall.function.arguments)")
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundColor(DesignSystem.Colors.textSecondary)
+                                .textSelection(.enabled)
+                        }
+                        .padding(.vertical, DesignSystem.Spacing.xs)
+                    }
+                }
+            } else {
+                Text("Empty message")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundColor(DesignSystem.Colors.textSecondary)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DesignSystem.Colors.surface)
+        .cornerRadius(DesignSystem.CornerRadius.md)
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.md)
+                .stroke(DesignSystem.Colors.border, lineWidth: 1)
+        )
+    }
+    
+    private func copyToClipboard(_ message: ChatMessage) {
+        let textToCopy: String
+        if let content = message.content, !content.isEmpty {
+            textToCopy = content
+        } else if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
+            textToCopy = toolCalls.map { "Tool: \($0.function.name), Args: \($0.function.arguments)" }.joined(separator: "\n")
+        } else {
+            textToCopy = ""
+        }
+        
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(textToCopy, forType: .string)
+    }
+}

--- a/LiteLog/Views/JsonView.swift
+++ b/LiteLog/Views/JsonView.swift
@@ -1,0 +1,65 @@
+
+import SwiftUI
+
+struct JsonView: View {
+    let title: String
+    let data: Data?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+            HStack {
+                Text(title)
+                    .font(DesignSystem.Typography.title)
+                    .foregroundColor(DesignSystem.Colors.textPrimary)
+                
+                Spacer()
+                
+                Button(action: {
+                    copyPayloadToClipboard(data)
+                }) {
+                    HStack(spacing: DesignSystem.Spacing.xs) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 12))
+                        Text("Copy")
+                            .font(DesignSystem.Typography.caption)
+                    }
+                }
+                .buttonStyle(LinearButtonStyle(variant: .ghost))
+                .foregroundColor(DesignSystem.Colors.textSecondary)
+            }
+            
+            TextView(text: prettyPrintedJsonString(from: data))
+                .frame(minHeight: 400)
+        }
+    }
+    
+    private func copyPayloadToClipboard(_ data: Data?) {
+        guard let data = data else { return }
+        
+        let prettyJsonString: String
+        if let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
+           let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) {
+            prettyJsonString = String(data: prettyData, encoding: .utf8) ?? ""
+        } else {
+            prettyJsonString = String(data: data, encoding: .utf8) ?? ""
+        }
+        
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(prettyJsonString, forType: .string)
+    }
+    
+    private func prettyPrintedJsonString(from data: Data?) -> String {
+        guard let data = data else { return "No data" }
+        
+        if data.count > 1024 * 1024 { // 1MB limit
+            return "Payload is too large to display (> 1MB). Please use the copy button."
+        }
+
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments),
+              let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) else {
+            return String(data: data, encoding: .utf8) ?? "Failed to decode as UTF-8 string"
+        }
+        return String(data: prettyData, encoding: .utf8) ?? ""
+    }
+}

--- a/LiteLog/Views/LinearPicker.swift
+++ b/LiteLog/Views/LinearPicker.swift
@@ -1,0 +1,42 @@
+
+import SwiftUI
+
+struct LinearPicker<T: Hashable & CustomStringConvertible>: View {
+    @Binding var selection: T
+    let options: [T]
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            ForEach(options, id: \.self) { option in
+                Button(action: { 
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selection = option
+                    }
+                }) {
+                    Text(option.description)
+                        .font(DesignSystem.Typography.bodyMedium)
+                        .padding(.horizontal, DesignSystem.Spacing.md)
+                        .padding(.vertical, DesignSystem.Spacing.sm)
+                        .background(
+                            ZStack {
+                                if selection == option {
+                                    RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.md)
+                                        .fill(DesignSystem.Colors.surface)
+                                        .shadow(radius: 2, y: 1)
+                                }
+                            }
+                        )
+                        .foregroundColor(selection == option ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+        .padding(DesignSystem.Spacing.xs)
+        .background(DesignSystem.Colors.background.opacity(0.5))
+        .cornerRadius(DesignSystem.CornerRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.lg)
+                .stroke(DesignSystem.Colors.border, lineWidth: 1)
+        )
+    }
+}

--- a/LiteLog/Views/LogDetailView.swift
+++ b/LiteLog/Views/LogDetailView.swift
@@ -1,4 +1,3 @@
-
 import SwiftUI
 
 struct LogDetailView: View {
@@ -129,63 +128,10 @@ struct LogDetailView: View {
     
     @ViewBuilder
     private func payloads(log: LogEntry) -> some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxl) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                HStack {
-                    Text("Request Payload")
-                        .font(DesignSystem.Typography.title)
-                        .foregroundColor(DesignSystem.Colors.textPrimary)
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        copyPayloadToClipboard(log.requestPayload)
-                    }) {
-                        HStack(spacing: DesignSystem.Spacing.xs) {
-                            Image(systemName: "doc.on.doc")
-                                .font(.system(size: 12))
-                            Text("Copy")
-                                .font(DesignSystem.Typography.caption)
-                        }
-                    }
-                    .buttonStyle(LinearButtonStyle(variant: .ghost))
-                    .foregroundColor(DesignSystem.Colors.textSecondary)
-                }
-                
-                TextView(text: prettyPrintedJsonString(from: log.requestPayload))
-                    .frame(minHeight: 400)
-            }
-            .padding(DesignSystem.Spacing.xl)
-            .linearCard()
-            
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                HStack {
-                    Text("Response Payload")
-                        .font(DesignSystem.Typography.title)
-                        .foregroundColor(DesignSystem.Colors.textPrimary)
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        copyPayloadToClipboard(log.responsePayload)
-                    }) {
-                        HStack(spacing: DesignSystem.Spacing.xs) {
-                            Image(systemName: "doc.on.doc")
-                                .font(.system(size: 12))
-                            Text("Copy")
-                                .font(DesignSystem.Typography.caption)
-                        }
-                    }
-                    .buttonStyle(LinearButtonStyle(variant: .ghost))
-                    .foregroundColor(DesignSystem.Colors.textSecondary)
-                }
-                
-                TextView(text: prettyPrintedJsonString(from: log.responsePayload))
-                    .frame(minHeight: 400)
-            }
-            .padding(DesignSystem.Spacing.xl)
-            .linearCard()
-        }
+        PayloadView(
+            requestPayload: log.requestPayload,
+            responsePayload: log.responsePayload
+        )
     }
     
     private func formattedDate(_ dateString: String) -> String {
@@ -206,37 +152,7 @@ struct LogDetailView: View {
         }
         return "--"
     }
-    
-    private func copyPayloadToClipboard(_ data: Data?) {
-        guard let data = data else { return }
-        
-        let prettyJsonString: String
-        if let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
-           let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) {
-            prettyJsonString = String(data: prettyData, encoding: .utf8) ?? ""
-        } else {
-            prettyJsonString = String(data: data, encoding: .utf8) ?? ""
-        }
-        
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(prettyJsonString, forType: .string)
-    }
 }
-
-    private func prettyPrintedJsonString(from data: Data?) -> String {
-        guard let data = data else { return "No data" }
-        
-        if data.count > 1024 * 1024 { // 1MB limit
-            return "Payload is too large to display (> 1MB). Please use the copy button."
-        }
-
-        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments),
-              let prettyData = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) else {
-            return String(data: data, encoding: .utf8) ?? "Failed to decode as UTF-8 string"
-        }
-        return String(data: prettyData, encoding: .utf8) ?? ""
-    }
 
 struct DetailRow: View {
     let label: String
@@ -259,5 +175,3 @@ struct DetailRow: View {
         .padding(.vertical, DesignSystem.Spacing.xs)
     }
 }
-
-

--- a/LiteLog/Views/PayloadView.swift
+++ b/LiteLog/Views/PayloadView.swift
@@ -1,0 +1,34 @@
+
+import SwiftUI
+
+struct PayloadView: View {
+    let requestPayload: Data?
+    let responsePayload: Data?
+
+    @State private var selectedView: ViewType = .formatted
+
+    enum ViewType: String, CaseIterable, CustomStringConvertible {
+        case formatted = "Formatted"
+        case json = "JSON"
+        
+        var description: String {
+            return self.rawValue
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxl) {
+            LinearPicker(selection: $selectedView, options: ViewType.allCases)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if selectedView == .formatted {
+                FormattedView(requestPayload: requestPayload, responsePayload: responsePayload)
+            } else {
+                JsonView(title: "Request Payload", data: requestPayload)
+                JsonView(title: "Response Payload", data: responsePayload)
+            }
+        }
+        .padding(DesignSystem.Spacing.xl)
+        .linearCard()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Inspired by [Linear](https://linear.app), LiteLog is dedicated to bringing a mod
 - **API Key Management**: Automatically fetches and displays all virtual API keys from your LiteLLM instance, with support for showing aliases or key names.
 - **Log Inspection**:
     - Clearly displays the log list for each key, including status, model, duration, cost, and other critical information.
-    - Click a log entry to view the full request and response payloads.
-    - Provides a one-click copy feature for JSON payloads.
+    - **Enhanced Payload Views**: Click a log entry to view full request and response payloads with new "Formatted" and "JSON" views.
+        - **"JSON" View**: Presents pretty-printed JSON with a one-click copy feature.
+        - **"Formatted" View (Phase 1)**: Displays chat messages extracted from payloads in a chat-bubble-like format, grouped by role (System, User, Assistant), each with a copy-to-clipboard button. **Now also handles and displays tool calls within Assistant messages, even if the content is empty.**
+    - **Intuitive View Switching**: Easily switch between "Formatted" and "JSON" payload views using a custom Linear-style picker.
 - **State Persistence**:
     - Automatically saves the LiteLLM Base URL and Admin API Key.
     - Remembers the last selected API key and automatically loads it on launch.

--- a/README_zh.md
+++ b/README_zh.md
@@ -26,8 +26,10 @@ LiteLog 的设计深受 [Linear](https://linear.app) 的启发，致力于在开
 - **API Key 管理**: 自动从 LiteLLM 实例获取并展示所有虚拟 API Key，支持按别名或名称显示。
 - **日志审查**:
     - 清晰地展示每个 Key 对应的日志列表，包含状态、模型、耗时、费用等关键信息。
-    - 点击单条日志可查看请求和响应的完整载荷 (Payload)。
-    - 提供一键复制 JSON 载荷功能。
+    - **增强的载荷视图**: 点击单条日志可查看请求和响应的完整载荷 (Payload)，并提供全新的「Formatted」（格式化）和「JSON」视图。
+        - **「JSON」视图**: 呈现美观的 JSON 格式数据，并提供一键复制功能。
+        - **「Formatted」视图 (阶段一)**: 以聊天气泡形式显示从载荷中提取的聊天消息，按角色（System, User, Assistant）分组，每条消息都带有复制到剪贴板功能。**现在，当 Assistant 消息内容为空但包含工具调用时，Formatted 视图会清晰地展示这些工具调用信息。**
+    - **直观的视图切换**: 使用自定义的 Linear 风格选择器，轻松切换「Formatted」和「JSON」载荷视图。
 - **状态持久化**:
     - 自动保存 LiteLLM 的 Base URL 和 Admin API Key。
     - 记住用户上次选择的 API Key，启动时自动加载。


### PR DESCRIPTION
- Introduced tabbed payload views (Formatted/JSON) in Log Detail.
- Implemented custom Linear-style picker for view switching.
- Added new data models for chat payloads (ChatMessage, ToolCall, FunctionCall, ChatRequestPayload, ChatResponsePayload).
- Refactored FormattedView to display messages in a chat-bubble-like format with copy functionality, including handling and displaying tool calls within Assistant messages.
- Updated technical documentation (gemini.md, claude.md) and user-facing READMEs (README.md, README_zh.md).