### PR TITLE
feat(ui): Polish and refine Formatted View layout

### DIFF
--- a/LiteLog/Models/Payload.swift
+++ b/LiteLog/Models/Payload.swift
@@ -22,6 +22,16 @@ struct ChatMessage: Codable, Hashable, Identifiable {
         // If content is nil, but toolCalls exist, we should ensure content is not just an empty string.
         // For now, we'll keep content as optional String.
     }
+    
+    var copyableString: String {
+        if let content = content, !content.isEmpty {
+            return content
+        } else if let toolCalls = toolCalls, !toolCalls.isEmpty {
+            return toolCalls.map { "Tool: \($0.function.name), Args: \($0.function.arguments)" }.joined(separator: "\n")
+        } else {
+            return ""
+        }
+    }
 }
 
 struct ToolCall: Codable, Hashable, Identifiable {

--- a/LiteLog/Views/DesignSystem.swift
+++ b/LiteLog/Views/DesignSystem.swift
@@ -225,3 +225,13 @@ extension Color {
         )
     }
 }
+
+struct SectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(DesignSystem.Typography.title)
+            .foregroundColor(DesignSystem.Colors.textPrimary)
+    }
+}

--- a/LiteLog/Views/JsonView.swift
+++ b/LiteLog/Views/JsonView.swift
@@ -8,9 +8,7 @@ struct JsonView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
             HStack {
-                Text(title)
-                    .font(DesignSystem.Typography.title)
-                    .foregroundColor(DesignSystem.Colors.textPrimary)
+                SectionHeader(title: title)
                 
                 Spacer()
                 

--- a/LiteLog/Views/ToolsSectionView.swift
+++ b/LiteLog/Views/ToolsSectionView.swift
@@ -8,10 +8,10 @@ struct ToolsSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            Text("Tools")
-                .font(DesignSystem.Typography.titleSmall)
-                .foregroundColor(DesignSystem.Colors.textSecondary)
-                .padding(.horizontal, DesignSystem.Spacing.md)
+            HStack {
+                SectionHeader(title: "Tools")
+                Spacer()
+            }
 
             LazyVStack(spacing: DesignSystem.Spacing.sm) {
                 ForEach(toolDefinitions) { tool in
@@ -41,6 +41,7 @@ struct ToolDefinitionRowView: View {
                             .font(DesignSystem.Typography.body)
                             .foregroundColor(DesignSystem.Colors.textSecondary)
                             .padding(.bottom, DesignSystem.Spacing.sm)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     if let parameters = toolDefinition.function.parameters,
@@ -54,10 +55,7 @@ struct ToolDefinitionRowView: View {
                         }
                     }
                 }
-                .padding(DesignSystem.Spacing.md)
-                .frame(maxWidth: .infinity)
-                .background(Color.black.opacity(0.1)) // Inner background
-                .cornerRadius(DesignSystem.CornerRadius.sm, corners: [.bottomLeft, .bottomRight])
+                .padding(.top, DesignSystem.Spacing.sm) // Add spacing between label and content
                 
             } label: {
                 // Label for the collapsible row
@@ -117,36 +115,31 @@ struct ParameterRowView: View {
     let property: PropertyDefinition
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             Text(name)
                 .font(DesignSystem.Typography.bodyMedium)
                 .foregroundColor(DesignSystem.Colors.textPrimary)
                 .padding(.bottom, DesignSystem.Spacing.xs)
             
-            HStack {
-                Text("Type")
-                    .foregroundColor(DesignSystem.Colors.textSecondary)
-                    .frame(width: 80, alignment: .leading)
-                Text(property.type)
-                    .foregroundColor(DesignSystem.Colors.textPrimary)
-                Spacer()
+            Grid(alignment: .leading, horizontalSpacing: DesignSystem.Spacing.lg, verticalSpacing: DesignSystem.Spacing.sm) {
+                GridRow {
+                    Text("Type")
+                    Text(property.type)
+                }
+                
+                if let description = property.description, !description.isEmpty {
+                    GridRow(alignment: .top) {
+                        Text("Description")
+                        Text(description)
+                    }
+                }
             }
             .font(DesignSystem.Typography.body)
-
-            if let description = property.description, !description.isEmpty {
-                HStack(alignment: .top) {
-                    Text("Description")
-                        .foregroundColor(DesignSystem.Colors.textSecondary)
-                        .frame(width: 80, alignment: .leading)
-                    Text(description)
-                        .foregroundColor(DesignSystem.Colors.textPrimary)
-                    Spacer()
-                }
-                .font(DesignSystem.Typography.body)
-            }
+            .foregroundColor(DesignSystem.Colors.textSecondary)
         }
-        .padding()
-        .background(Color.black.opacity(0.2))
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DesignSystem.Colors.backgroundSecondary)
         .cornerRadius(DesignSystem.CornerRadius.sm)
     }
 }


### PR DESCRIPTION
This commit addresses LLOG-14, performing a major UI polish of the Formatted View to improve visual hierarchy, consistency, and elegance.

- **Layout & Consistency:**
  - Created a reusable `SectionHeader` component to unify title styles across `FormattedView` and `JsonView`.
  - Fixed all padding and alignment issues to ensure titles and content are perfectly aligned.

- **Tool Definition View:**
  - Refined the expanded tool card layout, ensuring the description and parameter cards are left-aligned and full-width.
  - Improved the `ParameterRowView` by using a `Grid` for better alignment.

- **Message & Tool Call View:**
  - Redesigned the `ToolCallView` with an icon and structured layout for better readability.
  - Solved the `MessageCard` layout issues by moving the copy button to the role title row, allowing for clean, symmetrical padding on the card itself.

- **Code Quality:**
  - Refactored `copyToClipboard` logic by moving string generation into a `copyableString` computed property on the `ChatMessage` model.
  - Updated all technical documentation (`gemini.md`, `claude.md`) to reflect the new components and refactoring decisions.